### PR TITLE
Add toggle to exclude speaker from fallback titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ These environment variables and workflow inputs control behavior at runtime.
 | `ENRICH_OVERWRITE` | CLI/CI | bool | `false` | When enriching, overwrite non-empty `title` values instead of only filling blanks. |
 | `ENRICH_DEBUG` | CLI/CI | bool | `false` | Verbose enrichment logging (fetch/skip/overwrite decisions). |
 | `FALLBACK_PREPEND_TEXT` | CLI/CI | string | — | Prefix template for titles filled from `speaker`. Supports `{series}` placeholder; missing keys render empty and whitespace is collapsed. Max length: 128 chars. Example: `A {series} Talk by` → `A Optimization Seminar Talk by Alice`. |
+| `FALLBACK_INCLUDE_SPEAKER` | CLI/CI | bool | `true` | Include speaker name in fallback titles. Set to `0` to use only `FALLBACK_PREPEND_TEXT` template (e.g., `A {series} Talk` without speaker). CLI: `--no-fallback-speaker`. |
 | `BOT_BYPASS_HEADER_VALUE` | CLI/CI | string | `1` | Value sent as `x-wdsoit-bot-bypass` header during enrichment requests. |
 | `ENRICH_CONTENT` | CLI/CI | bool | `false` | Enable content scraping from the event page into `content` (fallback stays as ICS `DESCRIPTION` if not overwritten). |
 | `ENRICH_CONTENT_OVERWRITE` | CLI/CI | bool | `false` | Overwrite non-empty `content` when enriching. |
@@ -119,4 +120,5 @@ You can also provide a JSON config file via `--config` (copy from `transform_con
 
 CLI flags mirror the envs: `--enrich-titles`, `--enrich-overwrite`, `--enrich-content`, `--enrich-content-overwrite`, `--enrich-raw-details`, `--enrich-raw-details-overwrite`, `--enrich-raw-extracts`.
 `--exclude-series` accepts comma-separated names and can be repeated; it mirrors `EXCLUDE_SERIES`.
+`--no-fallback-speaker` disables including speaker in fallback titles; mirrors `FALLBACK_INCLUDE_SPEAKER=0`.
 

--- a/src/enrich.py
+++ b/src/enrich.py
@@ -519,13 +519,16 @@ def enrichment_overwrite_enabled(cli_flag: bool) -> bool:
     return os.getenv("ENRICH_OVERWRITE", "0") in {"1", "true", "yes", "on"}
 
 
-def fill_title_fallback(events: List[Dict], overwrite: bool = False) -> int:
-    """Fill missing/TBD titles from the speaker field.
+def fill_title_fallback(events: List[Dict], overwrite: bool = False, include_speaker: bool = True) -> int:
+    """Fill missing/TBD titles using FALLBACK_PREPEND_TEXT and optionally the speaker field.
 
     Behavior:
     - Treats title values that are empty/whitespace or case-insensitive 'TBD' as missing.
     - When `overwrite` is False (default), only fills when missing as defined above.
-    - When `overwrite` is True, replaces any existing title with the speaker value.
+    - When `overwrite` is True, replaces any existing title with the generated value.
+    - When `include_speaker` is True (default), appends speaker to the prefix template.
+    - When `include_speaker` is False, uses only the rendered FALLBACK_PREPEND_TEXT
+      (e.g., "A {series} Talk" without the speaker name).
 
     Returns the number of events whose title was set.
     """
@@ -549,28 +552,49 @@ def fill_title_fallback(events: List[Dict], overwrite: bool = False) -> int:
 
     count = 0
     for ev in events:
-        speaker = ev.get("speaker")
-        if not speaker:
-            continue
         existing = ev.get("title")
-        if overwrite or _is_missing(existing):
-            # Render prefix template with event fields (e.g., {series}) and
-            # collapse whitespace so blanks (like empty series) don't leave doubles.
-            prefix_rendered = ""
-            if raw_prefix_tmpl:
-                try:
-                    prefix_rendered = raw_prefix_tmpl.format_map(_SafeDict(ev))
-                except Exception:
-                    # On formatting error, fall back to raw literal
-                    prefix_rendered = raw_prefix_tmpl
-                prefix_rendered = " ".join(prefix_rendered.split())
-            use_prefix = bool(prefix_rendered) and len(prefix_rendered) < MAX_PREFIX_LEN
+        if not (overwrite or _is_missing(existing)):
+            continue
+
+        # Render prefix template with event fields (e.g., {series}) and
+        # collapse whitespace so blanks (like empty series) don't leave doubles.
+        prefix_rendered = ""
+        if raw_prefix_tmpl:
+            try:
+                prefix_rendered = raw_prefix_tmpl.format_map(_SafeDict(ev))
+            except Exception:
+                # On formatting error, fall back to raw literal
+                prefix_rendered = raw_prefix_tmpl
+            prefix_rendered = " ".join(prefix_rendered.split())
+
+        if include_speaker:
+            speaker = ev.get("speaker")
+            if not speaker:
+                continue
             speaker_str = str(speaker)
+            use_prefix = bool(prefix_rendered) and len(prefix_rendered) < MAX_PREFIX_LEN
             ev["title"] = (
                 f"{prefix_rendered} {speaker_str}" if use_prefix else speaker_str
             )
             count += 1
+        else:
+            # Without speaker, only set title if we have a non-empty prefix
+            if prefix_rendered and len(prefix_rendered) < MAX_PREFIX_LEN:
+                ev["title"] = prefix_rendered
+                count += 1
     return count
+
+
+def fallback_include_speaker_enabled(cli_flag: bool | None = None) -> bool:
+    """Check if fallback titles should include the speaker name.
+
+    Default is True (include speaker) for backwards compatibility.
+    Set FALLBACK_INCLUDE_SPEAKER=0 or --no-fallback-speaker to disable.
+    """
+    if cli_flag is not None:
+        return cli_flag
+    val = os.getenv("FALLBACK_INCLUDE_SPEAKER", "1")
+    return val.lower() in {"1", "true", "yes", "on"}
 
 
 def enrichment_content_enabled(cli_flag: bool) -> bool:

--- a/src/main.py
+++ b/src/main.py
@@ -22,6 +22,7 @@ from .enrich import (
     enrichment_enabled,
     enrichment_overwrite_enabled,
     fill_title_fallback,
+    fallback_include_speaker_enabled,
     enrich_content,
     enrichment_content_enabled,
     enrichment_content_overwrite_enabled,
@@ -238,6 +239,11 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help="Extract abstract and bio from rawEventDetails into separate fields (requires raw details enrichment)",
     )
     p.add_argument(
+        "--no-fallback-speaker",
+        action="store_true",
+        help="Don't include speaker name in fallback titles; use only FALLBACK_PREPEND_TEXT template (env FALLBACK_INCLUDE_SPEAKER=0)",
+    )
+    p.add_argument(
         "--exclude-series",
         action="append",
         default=None,
@@ -278,10 +284,16 @@ def main(argv: list[str] | None = None) -> int:
             f"errors={stats.errors} overwrite={'true' if overwrite else 'false'}"
         )
         # Post-process fallback: ensure no blank or 'TBD' titles remain.
-        # Fill from speaker for any events still missing a meaningful title.
-        filled = fill_title_fallback(data, overwrite=False)
+        # Fill from FALLBACK_PREPEND_TEXT template, optionally with speaker.
+        # Only pass cli_flag when --no-fallback-speaker is explicitly used
+        cli_no_speaker = getattr(ns, 'no_fallback_speaker', False)
+        include_speaker = fallback_include_speaker_enabled(
+            cli_flag=False if cli_no_speaker else None
+        )
+        filled = fill_title_fallback(data, overwrite=False, include_speaker=include_speaker)
         if filled:
-            print(f"Fallback populated {filled} titles from speaker field")
+            source = "speaker field" if include_speaker else "template"
+            print(f"Fallback populated {filled} titles from {source}")
 
     # Optional content enrichment (independent of title enrichment)
     do_content_enrich = enrichment_content_enabled(ns.enrich_content)

--- a/tests/test_title_fallback.py
+++ b/tests/test_title_fallback.py
@@ -1,5 +1,5 @@
 import os
-from src.enrich import fill_title_fallback
+from src.enrich import fill_title_fallback, fallback_include_speaker_enabled
 
 
 def test_fill_title_fallback_blank_and_tbd(monkeypatch):
@@ -56,3 +56,64 @@ def test_fill_title_fallback_with_series_placeholder(monkeypatch):
     # For missing/blank series, ensure we don't get double spaces
     assert events[1]["title"] == "A Talk by Bob"
     assert events[2]["title"] == "A Talk by Carol"
+
+
+def test_fill_title_fallback_without_speaker(monkeypatch):
+    """When include_speaker=False, use only the template without speaker name."""
+    monkeypatch.setenv("FALLBACK_PREPEND_TEXT", "A {series} Talk")
+    events = [
+        {"guid": "1", "speaker": "Alice", "title": "", "series": "Optimization Seminar"},
+        {"guid": "2", "speaker": "Bob", "title": "", "series": "Statistics"},
+        {"guid": "3", "speaker": "Carol", "title": "Existing"},
+    ]
+    filled = fill_title_fallback(events, overwrite=False, include_speaker=False)
+    assert filled == 2
+    assert events[0]["title"] == "A Optimization Seminar Talk"
+    assert events[1]["title"] == "A Statistics Talk"
+    assert events[2]["title"] == "Existing"
+
+
+def test_fill_title_fallback_without_speaker_no_template(monkeypatch):
+    """When include_speaker=False and no template, nothing should be filled."""
+    monkeypatch.delenv("FALLBACK_PREPEND_TEXT", raising=False)
+    events = [
+        {"guid": "1", "speaker": "Alice", "title": ""},
+    ]
+    filled = fill_title_fallback(events, overwrite=False, include_speaker=False)
+    assert filled == 0
+    assert events[0]["title"] == ""
+
+
+def test_fill_title_fallback_without_speaker_missing_series(monkeypatch):
+    """When include_speaker=False and series is missing, collapse spaces properly."""
+    monkeypatch.setenv("FALLBACK_PREPEND_TEXT", "A {series} Talk")
+    events = [
+        {"guid": "1", "speaker": "Alice", "title": ""},  # no series key
+        {"guid": "2", "speaker": "Bob", "title": "", "series": ""},
+    ]
+    filled = fill_title_fallback(events, overwrite=False, include_speaker=False)
+    assert filled == 2
+    assert events[0]["title"] == "A Talk"
+    assert events[1]["title"] == "A Talk"
+
+
+def test_fallback_include_speaker_enabled_default(monkeypatch):
+    """Default should be True (include speaker)."""
+    monkeypatch.delenv("FALLBACK_INCLUDE_SPEAKER", raising=False)
+    assert fallback_include_speaker_enabled() is True
+
+
+def test_fallback_include_speaker_enabled_env_false(monkeypatch):
+    """FALLBACK_INCLUDE_SPEAKER=0 should return False."""
+    monkeypatch.setenv("FALLBACK_INCLUDE_SPEAKER", "0")
+    assert fallback_include_speaker_enabled() is False
+
+
+def test_fallback_include_speaker_enabled_cli_override(monkeypatch):
+    """CLI flag should override env var."""
+    monkeypatch.setenv("FALLBACK_INCLUDE_SPEAKER", "1")
+    # CLI says no speaker
+    assert fallback_include_speaker_enabled(cli_flag=False) is False
+    # CLI says include speaker
+    monkeypatch.setenv("FALLBACK_INCLUDE_SPEAKER", "0")
+    assert fallback_include_speaker_enabled(cli_flag=True) is True


### PR DESCRIPTION
## Summary

Adds option to exclude speaker names from fallback titles per request from SEAS communications staff.

Closes #18

## Changes

- Add `FALLBACK_INCLUDE_SPEAKER` env var (default `1` for backwards compatibility)
- Add `--no-fallback-speaker` CLI flag
- Update `fill_title_fallback()` with `include_speaker` parameter
- Add `fallback_include_speaker_enabled()` helper function
- Add tests for new behavior
- Update README documentation

## Usage

```bash
# Use only template, no speaker name
FALLBACK_PREPEND_TEXT="A {series} Talk" FALLBACK_INCLUDE_SPEAKER=0 python -m src.main ...

# Or via CLI
python -m src.main --no-fallback-speaker ...
```

## Test plan

- [x] Unit tests for `include_speaker=False` behavior
- [x] Unit tests for `fallback_include_speaker_enabled()` helper
- [x] Local test with live ICS feed
- [x] Review by maintainer before merge